### PR TITLE
Release CGImageRef in OpenCVWrapper _matFrom

### DIFF
--- a/OpenCV/Classes/OpenCVWrapper.mm
+++ b/OpenCV/Classes/OpenCVWrapper.mm
@@ -1,5 +1,5 @@
 //
-//  OpenCVWrapper.m
+//  OpenCVWrapper.mm
 //  OpenCV
 //
 //  Created by Dmytro Nasyrov on 5/1/17.
@@ -71,6 +71,7 @@ using namespace cv;
     CGContextRef context = CGBitmapContextCreate(result.data, cols, rows, bitsPerComponent, bytesPerRow, colorSpace, bitmapFlags);
     CGContextDrawImage(context, CGRectMake(0.0f, 0.0f, cols, rows), image);
     CGContextRelease(context);
+    CGImageRelease(image);
     
     return result;
 }


### PR DESCRIPTION
Without this, memory leaks for every image processed by OpenCVWrapper

Thank you very much for your tutorial here: https://medium.com/pharos-production/using-opencv-in-a-swift-project-679868e1b798

I noticed that my app was leaking memory (it does OpenCV processing on every frame of a video feed, so the memory usage jumps quickly), but adding this `CGImageRelease` call fixes the problem.